### PR TITLE
Issue #22107: tempfile.gettempdir() and tempfile.mkdtemp() now try again

### DIFF
--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -205,9 +205,14 @@ def _get_default_tempdir():
                     _os.unlink(filename)
                 return dir
             except (OSError, IOError) as e:
-                if e.args[0] != _errno.EEXIST:
-                    break # no point trying more names in this directory
-                pass
+                if e.args[0] == _errno.EEXIST:
+                    continue
+                if (_os.name == 'nt' and e.args[0] == _errno.EACCES and
+                    _os.path.isdir(dir) and _os.access(dir, _os.W_OK)):
+                    # On windows, when a directory with the chosen name already
+                    # exists, EACCES error code is returned instead of EEXIST.
+                    continue
+                break # no point trying more names in this directory
     raise IOError, (_errno.ENOENT,
                     ("No usable temporary directory found in %s" % dirlist))
 
@@ -242,7 +247,8 @@ def _mkstemp_inner(dir, pre, suf, flags):
         except OSError, e:
             if e.errno == _errno.EEXIST:
                 continue # try again
-            if _os.name == 'nt' and e.errno == _errno.EACCES:
+            if (_os.name == 'nt' and e.errno == _errno.EACCES and
+                _os.path.isdir(dir) and _os.access(dir, _os.W_OK)):
                 # On windows, when a directory with the chosen name already
                 # exists, EACCES error code is returned instead of EEXIST.
                 continue
@@ -335,6 +341,11 @@ def mkdtemp(suffix="", prefix=template, dir=None):
         except OSError, e:
             if e.errno == _errno.EEXIST:
                 continue # try again
+            if (_os.name == 'nt' and e.errno == _errno.EACCES and
+                _os.path.isdir(dir) and _os.access(dir, _os.W_OK)):
+                # On windows, when a directory with the chosen name already
+                # exists, EACCES error code is returned instead of EEXIST.
+                continue
             raise
 
     raise IOError, (_errno.EEXIST, "No usable temporary directory name found")

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -15,6 +15,11 @@ Core and Builtins
 Library
 -------
 
+- Issue #22107: tempfile.gettempdir() and tempfile.mkdtemp() now try again
+  when a directory with the chosen name already exists on Windows as well as
+  on Unix.  tempfile.mkstemp() now fails early if parent directory is not
+  valid (not exists or is a file) on Windows.
+
 - Issue #6598: Increased time precision and random number range in
   email.utils.make_msgid() to strengthen the uniqueness of the message ID.
 


### PR DESCRIPTION
when a directory with the chosen name already exists on Windows as well as
on Unix.  tempfile.mkstemp() now fails early if parent directory is not
valid (not exists or is a file) on Windows.
