### PR TITLE
Issue #24326: Fixed audioop.ratecv() with non-default weightB argument.

### DIFF
--- a/Lib/test/test_audioop.py
+++ b/Lib/test/test_audioop.py
@@ -280,6 +280,9 @@ class TestAudioop(unittest.TestCase):
                              (b'', (-2, ((0, 0),))))
             self.assertEqual(audioop.ratecv(datas[w], w, 1, 8000, 8000, None)[0],
                              datas[w])
+            self.assertEqual(audioop.ratecv(datas[w], w, 1, 8000, 8000, None, 1, 0)[0],
+                             datas[w])
+
         state = None
         d1, state = audioop.ratecv(b'\x00\x01\x02', 1, 1, 8000, 16000, state)
         d2, state = audioop.ratecv(b'\x00\x01\x02', 1, 1, 8000, 16000, state)
@@ -294,6 +297,20 @@ class TestAudioop(unittest.TestCase):
                 d += d1
             self.assertEqual(d, d0)
             self.assertEqual(state, state0)
+
+        expected = {
+            1: packs[1](0, 0x0d, 0x37, -0x26, 0x55, -0x4b, -0x14),
+            2: packs[2](0, 0x0da7, 0x3777, -0x2630, 0x5673, -0x4a64, -0x129a),
+            3: packs[3](0, 0x0da740, 0x377776, -0x262fca,
+                        0x56740c, -0x4a62fd, -0x1298c0),
+            4: packs[4](0, 0x0da740da, 0x37777776, -0x262fc962,
+                        0x56740da6, -0x4a62fc96, -0x1298bf26),
+        }
+        for w in 1, 2, 3, 4:
+            self.assertEqual(audioop.ratecv(datas[w], w, 1, 8000, 8000, None, 3, 1)[0],
+                             expected[w])
+            self.assertEqual(audioop.ratecv(datas[w], w, 1, 8000, 8000, None, 30, 10)[0],
+                             expected[w])
 
     def test_reverse(self):
         for w in 1, 2, 4:

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -22,6 +22,9 @@ Core and Builtins
 Library
 -------
 
+- Issue #24326: Fixed audioop.ratecv() with non-default weightB argument.
+  Original patch by David Moore.
+
 - Issue #22095: Fixed HTTPConnection.set_tunnel with default port.  The port
   value in the host header was set to "None".  Patch by Demian Brecht.
 

--- a/Modules/audioop.c
+++ b/Modules/audioop.c
@@ -1130,7 +1130,7 @@ audioop_ratecv(PyObject *self, PyObject *args)
     /* divide weightA and weightB by their greatest common divisor */
     d = gcd(weightA, weightB);
     weightA /= d;
-    weightA /= d;
+    weightB /= d;
 
     if ((size_t)nchannels > PY_SIZE_MAX/sizeof(int)) {
         PyErr_SetString(PyExc_MemoryError,


### PR DESCRIPTION
Original patch by David Moore.
