### PR TITLE
Issue #24514: tarfile now tolerates number fields consisting of only …

### DIFF
--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -186,7 +186,7 @@ def nti(s):
     # itn() below.
     if s[0] != chr(0200):
         try:
-            n = int(nts(s) or "0", 8)
+            n = int(nts(s).strip() or "0", 8)
         except ValueError:
             raise InvalidHeaderError("invalid header")
     else:

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -1566,6 +1566,14 @@ class LimitsTest(unittest.TestCase):
         tarinfo.tobuf(tarfile.PAX_FORMAT)
 
 
+class MiscTest(unittest.TestCase):
+
+    def test_read_number_fields(self):
+        # Issue 24514: Test if empty number fields are converted to zero.
+        self.assertEqual(tarfile.nti("\0"), 0)
+        self.assertEqual(tarfile.nti("       \0"), 0)
+
+
 class ContextManagerTest(unittest.TestCase):
 
     def test_basic(self):
@@ -1730,6 +1738,7 @@ def test_main():
         PaxUnicodeTest,
         AppendTest,
         LimitsTest,
+        MiscTest,
         ContextManagerTest,
     ]
 

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -34,6 +34,9 @@ Core and Builtins
 Library
 -------
 
+- Issue #24514: tarfile now tolerates number fields consisting of only
+  whitespace.
+
 - Issue #20387: Restore semantic round-trip correctness in tokenize/untokenize
   for tab-indented blocks.
 


### PR DESCRIPTION
…whitespace.
