### PR TITLE
Issue #24611: Fixed compiling the posix module on non-Windows platforms

### DIFF
--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -34,6 +34,9 @@ Core and Builtins
 Library
 -------
 
+- Issue #24611: Fixed compiling the posix module on non-Windows platforms
+  without mknod() or makedev() (e.g. on Unixware).
+
 - Issue #18684: Fixed reading out of the buffer in the re module.
 
 - Issue #24259: tarfile now raises a ReadError if an archive is truncated

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -513,6 +513,8 @@ _Py_Dev_Converter(PyObject *obj, void *p)
     return 1;
 }
 
+#endif
+
 #ifdef HAVE_LONG_LONG
 static PyObject *
 _PyInt_FromDev(PY_LONG_LONG v)
@@ -524,8 +526,6 @@ _PyInt_FromDev(PY_LONG_LONG v)
 }
 #else
 #  define _PyInt_FromDev PyInt_FromLong
-#endif
-
 #endif
 
 


### PR DESCRIPTION
without mknod() or makedev() (e.g. on Unixware).
